### PR TITLE
Add 2-Opt rollout support

### DIFF
--- a/Search/code/include/TSP_Basic_Functions.h
+++ b/Search/code/include/TSP_Basic_Functions.h
@@ -1,4 +1,7 @@
 
+// Forward declaration for 2-Opt local search
+void Local_Search_by_2Opt_Move();
+
 // Return an integer between [0,Divide_Num)
 int Get_Random_Int(int Divide_Num)
 { 
@@ -275,4 +278,35 @@ Distance_Type Greedy_Rollout(int start_city)
     }
     total+=Get_Distance(cur,start_city);
     return total;
+}
+
+// Perform greedy rollout and then apply 2-Opt local search
+Distance_Type Greedy_Rollout_2Opt(int start_city)
+{
+    // Build a greedy tour stored in Solution[]
+    for(int i=0;i<Virtual_City_Num;i++)
+        If_City_Selected[i]=false;
+
+    int cur = start_city;
+    int visited = 1;
+    Solution[0] = cur;
+    If_City_Selected[cur] = true;
+
+    while(visited < Virtual_City_Num)
+    {
+        int next = Get_Neareast_Unselected_City(cur);
+        if(next==Null)
+            break;
+        Solution[visited++] = next;
+        If_City_Selected[next] = true;
+        cur = next;
+    }
+
+    // Close the tour
+    Convert_Solution_To_All_Node();
+
+    // Apply 2-Opt local search on the greedy tour
+    Local_Search_by_2Opt_Move();
+
+    return Get_Solution_Total_Distance();
 }

--- a/Search/code/include/TSP_IO.h
+++ b/Search/code/include/TSP_IO.h
@@ -48,6 +48,7 @@ int Index_In_Batch;
 int rec_only;
 int restart_reconly;
 int use_greedy_rollout = 0; // whether to evaluate leaf nodes by greedy rollout
+int use_2opt_rollout = 0; // whether to apply 2-Opt after greedy rollout
 
 /*
  * Here we define new array to store the recomend citys and corresponding value

--- a/Search/code/include/TSP_MCTS.h
+++ b/Search/code/include/TSP_MCTS.h
@@ -1,6 +1,11 @@
 #include <iostream>
 #include <fstream>
 
+// Forward declarations of functions defined elsewhere
+Distance_Type Greedy_Rollout(int start_city);
+Distance_Type Greedy_Rollout_2Opt(int start_city);
+bool Execute_Best_Action();
+
 
 // Initialize the parameters used in MCTS
 void MCTS_Init(int Inst_Index)
@@ -191,10 +196,14 @@ Distance_Type Get_Simulated_Action_Delta(int Begin_City)
 				
         Pair_City_Num=Best_Index+1;
 
-        if(use_greedy_rollout){
+        if(use_greedy_rollout || use_2opt_rollout){
                 Store_Best_Solution();
                 Execute_Best_Action();
-                Distance_Type rollout_dist = Greedy_Rollout(Start_City);
+                Distance_Type rollout_dist;
+                if(use_2opt_rollout)
+                        rollout_dist = Greedy_Rollout_2Opt(Start_City);
+                else
+                        rollout_dist = Greedy_Rollout(Start_City);
                 Restore_Best_Solution();
                 return Before_Distance - rollout_dist;
         }


### PR DESCRIPTION
## Summary
- integrate greedy rollout with optional 2-Opt local search
- add `use_2opt_rollout` flag in search parameters
- expose forward declarations for new functions

## Testing
- `g++ -std=c++11 code/TSP.cpp -Icode/include -o tsp_exec`
- `./tsp_exec` *(fails: Segmentation fault)*