### PR TITLE
Fix solver hanging on infeasible tours

### DIFF
--- a/Search/code/TSP.cpp
+++ b/Search/code/TSP.cpp
@@ -215,9 +215,8 @@ int main(int argc, char ** argv)
 			Index_In_Batch, Sum_Opt_Distance/Test_Inst_Num,Sum_My_Distance/Test_Inst_Num, Sum_Gap/Test_Inst_Num, ((double)clock()-Overall_Begin_Time)/CLOCKS_PER_SEC, Beat_Best_Known_Times, Match_Best_Known_Times, Miss_Best_Known_Times);
 	fclose(fp);
 	
-	printf("\n\nIndex_In_Batch: %d, Avg_Concorde_Distance: %f Avg_MCTS_Distance: %f Avg_Gap: %f Total_Time: %.2f Seconds \n Beat_Best_Known_Times: %d Match_Best_Known_Times: %d Miss_Best_Known_Times: %d \n",
-			Index_In_Batch, Sum_Opt_Distance/Test_Inst_Num,Sum_My_Distance/Test_Inst_Num, Sum_Gap/Test_Inst_Num, ((double)clock()-Overall_Begin_Time)/CLOCKS_PER_SEC, Beat_Best_Known_Times, Match_Best_Known_Times, Miss_Best_Known_Times);
-	getchar();
+        printf("\n\nIndex_In_Batch: %d, Avg_Concorde_Distance: %f Avg_MCTS_Distance: %f Avg_Gap: %f Total_Time: %.2f Seconds \n Beat_Best_Known_Times: %d Match_Best_Known_Times: %d Miss_Best_Known_Times: %d \n",
+                        Index_In_Batch, Sum_Opt_Distance/Test_Inst_Num,Sum_My_Distance/Test_Inst_Num, Sum_Gap/Test_Inst_Num, ((double)clock()-Overall_Begin_Time)/CLOCKS_PER_SEC, Beat_Best_Known_Times, Match_Best_Known_Times, Miss_Best_Known_Times);
 
 	return 0;
 }
@@ -274,12 +273,11 @@ bool Solve_Instances_In_Batch()
 	ifstream FIC;
 	FIC.open(Input_Inst_File_Name);  
   
-	if(FIC.fail())
-	{
-    	cout << "\n\nError! Fail to open file"<<Input_Inst_File_Name<<endl;
-    	getchar();
-    	return false;     
-	}
+        if(FIC.fail())
+        {
+        cout << "\n\nError! Fail to open file"<<Input_Inst_File_Name<<endl;
+        return false;
+        }
   	else
     	cout << "\n\nRead instances information from "<<Input_Inst_File_Name<<endl;
       	    

--- a/Search/code/include/TSP_Basic_Functions.h
+++ b/Search/code/include/TSP_Basic_Functions.h
@@ -105,9 +105,8 @@ bool Check_Solution_Feasible()
 		Visited_City_Num++;
 		if(Visited_City_Num > Virtual_City_Num)
 		{
-			printf("\nThe current solution is unvalid. Loop may exist\n");
-			getchar();
-			return false;
+                        printf("\nThe current solution is unvalid. Loop may exist\n");
+                        return false;
 		}
 				
 		if(Cur_City == Start_City && Visited_City_Num == Virtual_City_Num)	
@@ -126,9 +125,8 @@ Distance_Type Get_Solution_Total_Distance()
   	  		Solution_Total_Distance += Get_Distance(i,Temp_Next_City); 
   		else
   		{
-  			printf("\nGet_Solution_Total_Distance() fail!\n");
-  			getchar();
-  			return Inf_Cost;
+                        printf("\nGet_Solution_Total_Distance() fail!\n");
+                        return Inf_Cost;
 		}  	  		
   	}	
   
@@ -161,9 +159,8 @@ double Get_Current_Solution_Double_Distance()
   	  		Current_Solution_Double_Distance += Calculate_Double_Distance(i,Temp_Next_City);
   		else
   		{
-  			printf("\nGet_Current_Solution_Double_Distance() fail!\n");
-  			getchar();
-  			return Inf_Cost;
+                        printf("\nGet_Current_Solution_Double_Distance() fail!\n");
+                        return Inf_Cost;
 		}  	  		
   	}	
   


### PR DESCRIPTION
## Summary
- avoid pausing on infeasible tours in core utility functions
- remove blocking `getchar` calls from the main driver

## Testing
- `make -C Search`
- `./Search/test 0 tmp.txt 1kTraning_TSP200Instance_128.txt 200 0 0 30 3 0.5 0.5 1 0 0` *(terminated after a few seconds)*